### PR TITLE
Use existing `QApplication`

### DIFF
--- a/runmanager/__main__.py
+++ b/runmanager/__main__.py
@@ -3780,7 +3780,9 @@ if __name__ == "__main__":
     logger = setup_logging('runmanager')
     labscript_utils.excepthook.set_logger(logger)
     logger.info('\n\n===============starting===============\n')
-    qapplication = QtWidgets.QApplication(sys.argv)
+    qapplication = QtWidgets.QApplication.instance()
+    if qapplication is None:
+        qapplication = QtWidgets.QApplication(sys.argv)
     qapplication.setAttribute(QtCore.Qt.AA_DontShowIconsInMenus, False)
     app = RunManager()
     splash.update_text('Starting remote server')


### PR DESCRIPTION
Instead of creating a new one unconditionally. The splash screen already
creates a `QApplication`, so we had two existing in the interpreter.
Having multiple `QApplication`s in the same thread (possibly in the same
process?) is not allowed and leads to segfaults on `PyQt5` and Python
exceptions on `PySide2`.

Fixes #74