### PR TITLE
Use `desktop-app` package for desktop integration

### DIFF
--- a/runmanager/desktop-app.json
+++ b/runmanager/desktop-app.json
@@ -1,0 +1,1 @@
+{"product_name": "Labscript Suite"}

--- a/runmanager/desktop-app.json
+++ b/runmanager/desktop-app.json
@@ -1,1 +1,4 @@
-{"product_name": "Labscript Suite"}
+{
+    "product_name": "Labscript Suite",
+    "modules": {"runmanager": {"display_name": "runmanager - the labscript suite"}}
+}

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ INSTALL_REQUIRES = [
     "labscript_utils >=2.12.5",
     "qtutils >=2.2.2",
     "pandas >=0.13",
+    "desktop-app",
 ]
 
 setup(
@@ -64,6 +65,10 @@ setup(
     url='http://labscriptsuite.org',
     license="BSD",
     packages=["runmanager"],
+    entry_points={
+        'console_scripts': ['runmanager = desktop_app:entry_point'],
+        'gui_scripts': ["runmanager-gui = desktop_app:entry_point"],
+    },
     zip_safe=False,
     setup_requires=['setuptools', 'setuptools_scm'],
     include_package_data=True,


### PR DESCRIPTION
Instead of `labscript_utils.winshell` and `labscript_utils.winlauncher`.

The `desktop-app` package has been split off from the functionality in `labscript_utils` into a separate package in order to encapsulate it a bit better, and generalise it to Linux (macos support planned). I'm in the process of documenting it, but as you can see from this PR, plugging an app into it is pretty simple. 

With this you should be able to `pip install -e .`, then run `desktop-app install runmanager` to get start menu shortcuts (or DE menu shortcuts in Linux). My intention is that we will make a `labscript-install-shortcuts` `entry_point` or something like that, or integrate it with `labscript-profile-create`, that will call this for every labscript suite module. Not sure at this point.

You'll want to clone `desktop-app` [from my github](https://github.com/chrisjbillington/desktop-app) into your venv since I have yet to put it on PyPi. Just doing a bit more testing and getting some documentation and an example in place. Git blame says that I wrote all of `winlauncher` and `winshell` so I've got the license there saying copyright me, but if anyone remembers otherwise, please let me know. 

`desktop-app` uses defaults that match basically what we were doing already, but it uses the module name by default as the shortcut name - so in the start menu this will result in just 'runmanager' instead of 'runmanager - the labscript suite' or whatever it was before. Since `{"product_name": "Labscript Suite"}` is specified in `runmanager/desktop-app.json` (this is how `desktop-app` gets its config), it does install the start menu shortcuts to a "Labscript Suite" subfolder of the start menu. If we want to change the name, we can set `"display_name": "runmanager - the labscript suite"` if we like.

once installed, runmanager can be run from the terminal with `runmanager` or
`runmanager-gui` to run without a console on Windows. This can be done regardless of whether you've run the install command to create a start menu shortcut, but the taskbar behaviour will not be correct if you have not installed a shortcut. This is because instead of setting the `AppUserModelID` on a per-window basis, we're now setting it on the whole process level, which is much simpler and doesn't require us to hook into Qt events every time we display a non-modal window. However, setting the `AppUserModelID` at the whole-process level does not allow to set a relaunch command, or icon, or anything - [it needs to associate with a shortcut](https://docs.microsoft.com/en-us/windows/win32/shell/appids#where-to-assign-an-appusermodelid).

> If a shortcut exists to launch the application, an application should apply the AppUserModelID as a property of the shortcut instead of using the relaunch properties. In that case, the command line, icon, and text of the shortcut are used to supply the same information as the relaunch properties.

As a workaround so that things still look nice during development, I could make the launcher process (what used to be `labscript_utils.winlauncher`) *create a shortcut in a temporary directory* if it detects that no shortcut has been installed to the start menu. Since the wrapper process is pretty simple, it would even clean up after itself pretty reliably even if runmanager crashed hard.

Fixes #73 