### PR TITLE
Obtain own version without external functions

### DIFF
--- a/runmanager/__init__.py
+++ b/runmanager/__init__.py
@@ -48,11 +48,7 @@ from labscript_utils.ls_zprocess import ProcessTree, zmq_push_multipart
 from labscript_utils.labconfig import LabConfig
 process_tree = ProcessTree.instance()
 
-from labscript_utils.versions import get_version, NoVersionInfo
-from pathlib import Path
-__version__ = get_version(__name__, import_path=Path(__file__).parent.parent)
-if __version__ is NoVersionInfo:
-    __version__ = None
+from .__version__ import __version__
 
 
 def _ensure_str(s):

--- a/runmanager/__version__.py
+++ b/runmanager/__version__.py
@@ -1,5 +1,5 @@
 import os
-from setuptools_scm import get_version
+from pathlib import Path
 try:
     import importlib.metadata as importlib_metadata
 except ImportError:
@@ -10,13 +10,12 @@ VERSION_SCHEME = {
     "local_scheme": os.getenv("SCM_LOCAL_SCHEME", "node-and-date"),
 }
 
-try:
-    __version__ = importlib_metadata.version(__package__)
-except importlib_metadata.PackageNotFoundError:
-    __version__ = None
-
-
-__version__ = get_version(
-    '..', relative_to=__file__, fallback_version=__version__, **VERSION_SCHEME
-)
-        
+root = Path(__file__).parent.parent
+if (root / '.git').is_dir():
+    from setuptools_scm import get_version
+    __version__ = get_version(root, **VERSION_SCHEME)
+else:
+    try:
+        __version__ = importlib_metadata.version(__package__)
+    except importlib_metadata.PackageNotFoundError:
+        __version__ = None

--- a/runmanager/__version__.py
+++ b/runmanager/__version__.py
@@ -1,0 +1,22 @@
+import os
+from setuptools_scm import get_version
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    import importlib_metadata
+
+VERSION_SCHEME = {
+    "version_scheme": os.getenv("SCM_VERSION_SCHEME", "guess-next-dev"),
+    "local_scheme": os.getenv("SCM_LOCAL_SCHEME", "node-and-date"),
+}
+
+try:
+    __version__ = importlib_metadata.version(__package__)
+except importlib_metadata.PackageNotFoundError:
+    __version__ = None
+
+
+__version__ = get_version(
+    '..', relative_to=__file__, fallback_version=__version__, **VERSION_SCHEME
+)
+        

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ packages = find:
 python_requires = >=3.6
 install_requires =
   desktop-app>=0.1.2
+  importlib_metadata
   labscript
   labscript_utils>=2.12.5
   pandas>=0.13


### PR DESCRIPTION
Don't import labscript_utils to get own version,
instead rely on simpler check within `__version__.py`

This returns setuptools_scm's version wit the given config if in a VCS folder, otherwise falling back to whatever importlib_metadata returns.

Unfortunately this means duplicating some configuration in `setup.py` and `__version__.py` to ensure they give identical results, but I think it's for the best

We could have kept this version check function within labscript_utils, but I think it makes more sense to keep it in each project so that it can stay in sync with that project's config rather than labscript-suite-wide config that if in labscript-utils will not necessarily change in sync with each project. So I think it's better if each project is in charge of its own version checks.

With this change and changes like #80, labscript_utils.versions starts to play a much more minor role and can be stripped down and have much of its complexity and magic removed.