### PR TITLE
Resolve warnings from Qt about an alpha being declared in an RGB colour

### DIFF
--- a/runmanager/main.ui
+++ b/runmanager/main.ui
@@ -157,8 +157,8 @@ QToolButton:hover:checked {
            </property>
            <property name="styleSheet">
             <string notr="true">QPushButton {
-	 background-color: rgb(238,96,96,192);
-     border: 1px solid rgb(238,96,96,128);
+	 background-color: rgba(238,96,96,192);
+     border: 1px solid rgba(238,96,96,128);
 	  border-radius: 3px;
      padding: 4px;
  }


### PR DESCRIPTION
There were some Qt warnings being printed to the terminal about CSS not being strictly correct. This makes them go away.