### PR TITLE
More intuitive open-file icon.

### DIFF
--- a/runmanager/main.ui
+++ b/runmanager/main.ui
@@ -371,7 +371,7 @@ subprocess</string>
            </property>
            <property name="icon">
             <iconset>
-             <normaloff>:/qtutils/fugue/document--pencil.png</normaloff>:/qtutils/fugue/document--pencil.png</iconset>
+             <normaloff>:/qtutils/custom/python-document.png</normaloff>:/qtutils/custom/python-document.png</iconset>
            </property>
           </widget>
          </item>
@@ -555,7 +555,7 @@ QToolButton:hover {
               </property>
               <property name="icon">
                <iconset>
-                <normaloff>:/qtutils/custom/python-document.png</normaloff>:/qtutils/custom/python-document.png</iconset>
+                <normaloff>:/qtutils/fugue/folder-open-document-text.png</normaloff>:/qtutils/fugue/folder-open-document-text.png</iconset>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
Set the "select a labscript file" icon to a standard "open a file" icon
of an open folder with a file coming out of it.

Set the "edit a file" icon to a python document icon.

This is something that has always bugged me.

Before:

![image](https://user-images.githubusercontent.com/1044087/82255820-4e03d300-9923-11ea-8497-f9144e0c3497.png)

After:

![image](https://user-images.githubusercontent.com/1044087/82255784-3b899980-9923-11ea-8959-a06993e85f9c.png)
