### PR TITLE
Fix issue #92

### DIFF
--- a/runmanager/__main__.py
+++ b/runmanager/__main__.py
@@ -3483,7 +3483,8 @@ class RunManager(object):
             # Runviewer not running, start it:
             if os.name == 'nt':
                 creationflags = 0x00000008  # DETACHED_PROCESS from the win32 API
-                subprocess.Popen([sys.executable, '-m', 'runviewer'],
+                scripts_dir = desktop_app.environment.get_scripts_dir('runviewer')
+                subprocess.Popen([str(scripts_dir / 'runviewer-gui')],
                                  creationflags=creationflags, stdout=None, stderr=None,
                                  close_fds=True)
             else:


### PR DESCRIPTION
Launch runviewer using the runviewer-gui launcher, for consistency with
how it would be launched by a human, and to ensure it has a hidden
console window of its own instead of no console window (the cause of
issue #92).