### PR TITLE
Make runmanager remote timeout configurable

### DIFF
--- a/runmanager/remote.py
+++ b/runmanager/remote.py
@@ -7,17 +7,24 @@ from labscript_utils.labconfig import LabConfig
 class Client(ZMQClient):
     """A ZMQClient for communication with runmanager"""
 
-    def __init__(self, host=None, port=None):
+    def __init__(self, host=None, port=None, timeout=None):
         ZMQClient.__init__(self)
         if host is None:
             host = LabConfig().get('servers', 'runmanager', fallback='localhost')
         if port is None:
             port = LabConfig().getint('ports', 'runmanager', fallback=DEFAULT_PORT)
+        if timeout is None:
+            timeout = LabConfig().getfloat(
+                'timeouts', 'communication_timeout', fallback=60
+            )
         self.host = host
         self.port = port
+        self.timeout = timeout
 
     def request(self, command, *args, **kwargs):
-        return self.get(self.port, self.host, data=[command, args, kwargs], timeout=60)
+        return self.get(
+            self.port, self.host, data=[command, args, kwargs], timeout=self.timeout
+        )
 
     def say_hello(self):
         """Ping the runmanager server for a response"""
@@ -105,6 +112,7 @@ class Client(ZMQClient):
     def reset_shot_output_folder(self):
         """Reset the shot output folder to the default path"""
         return self.request('reset_shot_output_folder')
+
 
 _default_client = Client()
 

--- a/runmanager/remote.py
+++ b/runmanager/remote.py
@@ -17,7 +17,7 @@ class Client(ZMQClient):
         self.port = port
 
     def request(self, command, *args, **kwargs):
-        return self.get(self.port, self.host, data=[command, args, kwargs], timeout=15)
+        return self.get(self.port, self.host, data=[command, args, kwargs], timeout=60)
 
     def say_hello(self):
         """Ping the runmanager server for a response"""


### PR DESCRIPTION
## Issue

In the past (see [here](https://bitbucket-archive.labscriptsuite.org/#!/labscript_suite/runmanager/pull-requests/39/page/1)) the runmanager remote timeout had to be increased to account for the fact that updating globals can take a while. However as mentioned [here](https://github.com/rpanderson/analysislib-mloop/issues/4) I've still seen timeouts on my machine even after that PR bumped up the period up to 15 seconds.

## Updated Proposal:

Add support for a `communication_timeout` option in the `[timeouts]` section of the labconfig.

## Original proposal:

This PR proposes simply bumping up the timeout period to 60 seconds. I haven't seen that fail yet on my machine.