### PR TITLE
WIP: Compilation queue

### DIFF
--- a/runmanager/__init__.py
+++ b/runmanager/__init__.py
@@ -737,17 +737,47 @@ def make_run_files(
     created at some point, simply convert the returned generator to a list. The
     filenames the run files are given is simply the sequence_id with increasing integers
     appended."""
-    basename = os.path.join(output_folder, filename_prefix)
-    nruns = len(shots)
-    ndigits = int(np.ceil(np.log10(nruns)))
     if shuffle:
         random.shuffle(shots)
-    for i, shot_globals in enumerate(shots):
-        runfilename = ('%s_%0' + str(ndigits) + 'd.h5') % (basename, i)
+    run_filenames = make_run_filenames(output_folder, filename_prefix, len(shots))
+    for run_no, (filename, shot_globals) in enumerate(zip(run_filenames, shots)):
         make_single_run_file(
-            runfilename, sequence_globals, shot_globals, sequence_attrs, i, nruns
+            filename, sequence_globals, shot_globals, sequence_attrs, run_no, len(shots)
         )
-        yield runfilename
+        yield filename
+
+
+def make_run_filenames(output_folder, filename_prefix, nruns):
+    """Like make_run_files(), but return the filenames instead of creating the the files
+    (and instead of creating a generator that creates them). These filenames can then be
+    passed to make_single_run_file(). So instead of:
+
+    run_files = make_run_files(
+        output_folder,
+        sequence_globals,
+        shots,
+        sequence_attrs,
+        filename_prefix,
+        shuffle,
+    )
+
+    You may do:
+
+    if shuffle:
+        random.shuffle(shots)
+    run_filenames = make_run_filenames(output_folder, filename_prefix, len(shots))
+    for run_no, (filename, shot_globals) in enumerate(zip(run_filenames, shots)):
+        make_single_run_file(
+            filename, sequence_globals, shot_globals, sequence_attrs, run_no, len(shots)
+        )
+    """
+    basename = os.path.join(output_folder, filename_prefix)
+    ndigits = int(np.ceil(np.log10(nruns)))
+    filenames = []
+    for i in range(nruns):
+        filename = ('%s_%0' + str(ndigits) + 'd.h5') % (basename, i)
+        filenames.append(filename)
+    return filenames
 
 
 def make_single_run_file(filename, sequenceglobals, runglobals, sequence_attrs, run_no, n_runs):

--- a/runmanager/__main__.py
+++ b/runmanager/__main__.py
@@ -1571,7 +1571,11 @@ class RunManager(object):
         self.action_repeat_last = QtWidgets.QAction(
             QtGui.QIcon(self.ICON_REPEAT_LAST), 'Repeat last', self.ui
         )
-        
+
+        # Hide this initially, TODO remove this line once we are restoring from settings
+        # whether delayed compilation is enabled or not.
+        self.ui.delay_compilation_options.setVisible(False)
+
         self.repeat_mode_menu.addAction(self.action_repeat_all)
         self.repeat_mode_menu.addAction(self.action_repeat_last)
         self.ui.repeat_mode_select_button.setMenu(self.repeat_mode_menu)
@@ -3412,6 +3416,11 @@ class RunManager(object):
                     except Exception:
                         self.output_box.output(traceback.format_exc() + '\n', red=True)
                         self.compilation_aborted.set()
+                        # TODO: can probably think of something more sensible here,
+                        # like prepending to the queue and pausing it, unless the
+                        # user deletes the shot:
+                        inmain(self.queue_model.clear)
+                        self.queued_shots.clear()
                 inmain(self.ui.pushButton_abort.setEnabled, False)
                 self.compilation_aborted.clear()
             except Exception:
@@ -3940,7 +3949,8 @@ class RemoteServer(ZMQServer):
     def handle_reset_shot_output_folder(self):
         app.on_reset_shot_output_folder_clicked(None)
 
-    def advise_BLACS_shots_remaining(self, value):
+    def handle_advise_BLACS_shots_remaining(self, value):
+        print("BLACS said how many shots it has:", value)
         app.BLACS_shots_remaining_events.put(value)
         app.compilation_potentially_required.set()
 

--- a/runmanager/main.ui
+++ b/runmanager/main.ui
@@ -14,7 +14,7 @@
    <string>runmanager - the labscript suite</string>
   </property>
   <property name="windowIcon">
-   <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+   <iconset resource="../../qtutils/icons/icons.qrc">
     <normaloff>:/qtutils/custom/runmanager.png</normaloff>:/qtutils/custom/runmanager.png</iconset>
   </property>
   <property name="styleSheet">
@@ -141,7 +141,7 @@ QToolButton:hover:checked {
             <string>Shuffle</string>
            </property>
            <property name="icon">
-            <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+            <iconset resource="../../qtutils/icons/icons.qrc">
              <normaloff>:/qtutils/fugue/arrow-switch.png</normaloff>:/qtutils/fugue/arrow-switch.png</iconset>
            </property>
            <property name="checkable">
@@ -165,7 +165,7 @@ QToolButton:hover:checked {
 subprocess</string>
            </property>
            <property name="icon">
-            <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+            <iconset resource="../../qtutils/icons/icons.qrc">
              <normaloff>:/qtutils/fugue/arrow-circle-135-left.png</normaloff>:/qtutils/fugue/arrow-circle-135-left.png</iconset>
            </property>
           </widget>
@@ -186,7 +186,7 @@ subprocess</string>
             <string>Abort</string>
            </property>
            <property name="icon">
-            <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+            <iconset resource="../../qtutils/icons/icons.qrc">
              <normaloff>:/qtutils/fugue/cross-octagon.png</normaloff>:/qtutils/fugue/cross-octagon.png</iconset>
            </property>
           </widget>
@@ -231,7 +231,7 @@ QPushButton:hover {
             <string>Engage</string>
            </property>
            <property name="icon">
-            <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+            <iconset resource="../../qtutils/icons/icons.qrc">
              <normaloff>:/qtutils/fugue/control.png</normaloff>:/qtutils/fugue/control.png</iconset>
            </property>
            <property name="autoDefault">
@@ -328,7 +328,7 @@ QPushButton:hover {
             <string>...</string>
            </property>
            <property name="icon">
-            <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+            <iconset resource="../../qtutils/icons/icons.qrc">
              <normaloff>:/qtutils/fugue/document--pencil.png</normaloff>:/qtutils/fugue/document--pencil.png</iconset>
            </property>
           </widget>
@@ -431,7 +431,7 @@ QToolButton:hover {
                <string>...</string>
               </property>
               <property name="icon">
-               <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+               <iconset resource="../../qtutils/icons/icons.qrc">
                 <normaloff>:/qtutils/custom/python-document.png</normaloff>:/qtutils/custom/python-document.png</iconset>
               </property>
              </widget>
@@ -451,7 +451,7 @@ QToolButton:hover {
             <string>...</string>
            </property>
            <property name="icon">
-            <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+            <iconset resource="../../qtutils/icons/icons.qrc">
              <normaloff>:/qtutils/fugue/arrow-turn-180-left.png</normaloff>:/qtutils/fugue/arrow-turn-180-left.png</iconset>
            </property>
           </widget>
@@ -520,7 +520,7 @@ QToolButton:hover {
                <string/>
               </property>
               <property name="pixmap">
-               <pixmap resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">:/qtutils/fugue/exclamation-white.png</pixmap>
+               <pixmap resource="../../qtutils/icons/icons.qrc">:/qtutils/fugue/exclamation-white.png</pixmap>
               </property>
              </widget>
             </item>
@@ -560,7 +560,7 @@ QToolButton:hover {
                <string>...</string>
               </property>
               <property name="icon">
-               <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+               <iconset resource="../../qtutils/icons/icons.qrc">
                 <normaloff>:/qtutils/fugue/folder-horizontal-open.png</normaloff>:/qtutils/fugue/folder-horizontal-open.png</iconset>
               </property>
              </widget>
@@ -634,7 +634,7 @@ QToolButton:hover {
       </property>
       <widget class="QWidget" name="tab_output">
        <attribute name="icon">
-        <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+        <iconset resource="../../qtutils/icons/icons.qrc">
          <normaloff>:/qtutils/fugue/terminal.png</normaloff>:/qtutils/fugue/terminal.png</iconset>
        </attribute>
        <attribute name="title">
@@ -666,7 +666,7 @@ QToolButton:hover {
       </widget>
       <widget class="QWidget" name="tab_queue">
        <attribute name="icon">
-        <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+        <iconset resource="../../qtutils/icons/icons.qrc">
          <normaloff>:/qtutils/fugue/edit-list-order.png</normaloff>:/qtutils/fugue/edit-list-order.png</iconset>
        </attribute>
        <attribute name="title">
@@ -712,7 +712,7 @@ QToolButton:hover {
                     <string>delay compilation</string>
                    </property>
                    <property name="icon">
-                    <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+                    <iconset resource="../../qtutils/icons/icons.qrc">
                      <normaloff>:/qtutils/fugue/alarm-clock--arrow.png</normaloff>:/qtutils/fugue/alarm-clock--arrow.png</iconset>
                    </property>
                    <property name="checkable">
@@ -881,7 +881,7 @@ QToolButton:hover {
                     <string>Pause</string>
                    </property>
                    <property name="icon">
-                    <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+                    <iconset resource="../../qtutils/icons/icons.qrc">
                      <normaloff>:/qtutils/fugue/control-pause.png</normaloff>:/qtutils/fugue/control-pause.png</iconset>
                    </property>
                    <property name="checkable">
@@ -912,7 +912,7 @@ QToolButton:hover {
                       <string>Repeat</string>
                      </property>
                      <property name="icon">
-                      <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+                      <iconset resource="../../qtutils/icons/icons.qrc">
                        <normaloff>:/qtutils/fugue/arrow-repeat.png</normaloff>:/qtutils/fugue/arrow-repeat.png</iconset>
                      </property>
                      <property name="checkable">
@@ -929,7 +929,7 @@ QToolButton:hover {
                       <string/>
                      </property>
                      <property name="icon">
-                      <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+                      <iconset resource="../../qtutils/icons/icons.qrc">
                        <normaloff>:/qtutils/fugue/control-270.png</normaloff>:/qtutils/fugue/control-270.png</iconset>
                      </property>
                      <property name="iconSize">
@@ -993,7 +993,7 @@ QToolButton:hover {
                  <string>...</string>
                 </property>
                 <property name="icon">
-                 <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+                 <iconset resource="../../qtutils/icons/icons.qrc">
                   <normaloff>:/qtutils/fugue/minus.png</normaloff>:/qtutils/fugue/minus.png</iconset>
                 </property>
                </widget>
@@ -1020,7 +1020,7 @@ QToolButton:hover {
                  <string>...</string>
                 </property>
                 <property name="icon">
-                 <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+                 <iconset resource="../../qtutils/icons/icons.qrc">
                   <normaloff>:/qtutils/fugue/arrow-stop-090.png</normaloff>:/qtutils/fugue/arrow-stop-090.png</iconset>
                 </property>
                </widget>
@@ -1034,7 +1034,7 @@ QToolButton:hover {
                  <string>...</string>
                 </property>
                 <property name="icon">
-                 <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+                 <iconset resource="../../qtutils/icons/icons.qrc">
                   <normaloff>:/qtutils/fugue/arrow-090.png</normaloff>:/qtutils/fugue/arrow-090.png</iconset>
                 </property>
                </widget>
@@ -1048,7 +1048,7 @@ QToolButton:hover {
                  <string>...</string>
                 </property>
                 <property name="icon">
-                 <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+                 <iconset resource="../../qtutils/icons/icons.qrc">
                   <normaloff>:/qtutils/fugue/arrow-270.png</normaloff>:/qtutils/fugue/arrow-270.png</iconset>
                 </property>
                </widget>
@@ -1062,7 +1062,7 @@ QToolButton:hover {
                  <string>...</string>
                 </property>
                 <property name="icon">
-                 <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+                 <iconset resource="../../qtutils/icons/icons.qrc">
                   <normaloff>:/qtutils/fugue/arrow-stop-270.png</normaloff>:/qtutils/fugue/arrow-stop-270.png</iconset>
                 </property>
                </widget>
@@ -1103,7 +1103,7 @@ QToolButton:hover {
       </widget>
       <widget class="QWidget" name="tab_axes">
        <attribute name="icon">
-        <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+        <iconset resource="../../qtutils/icons/icons.qrc">
          <normaloff>:/qtutils/custom/outer.png</normaloff>:/qtutils/custom/outer.png</iconset>
        </attribute>
        <attribute name="title">
@@ -1161,7 +1161,7 @@ QToolButton:hover {
              <string>...</string>
             </property>
             <property name="icon">
-             <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+             <iconset resource="../../qtutils/icons/icons.qrc">
               <normaloff>:/qtutils/fugue/arrow-stop-090.png</normaloff>:/qtutils/fugue/arrow-stop-090.png</iconset>
             </property>
            </widget>
@@ -1175,7 +1175,7 @@ QToolButton:hover {
              <string>...</string>
             </property>
             <property name="icon">
-             <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+             <iconset resource="../../qtutils/icons/icons.qrc">
               <normaloff>:/qtutils/fugue/arrow-090.png</normaloff>:/qtutils/fugue/arrow-090.png</iconset>
             </property>
            </widget>
@@ -1189,7 +1189,7 @@ QToolButton:hover {
              <string>...</string>
             </property>
             <property name="icon">
-             <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+             <iconset resource="../../qtutils/icons/icons.qrc">
               <normaloff>:/qtutils/fugue/arrow-270.png</normaloff>:/qtutils/fugue/arrow-270.png</iconset>
             </property>
            </widget>
@@ -1203,7 +1203,7 @@ QToolButton:hover {
              <string>...</string>
             </property>
             <property name="icon">
-             <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+             <iconset resource="../../qtutils/icons/icons.qrc">
               <normaloff>:/qtutils/fugue/arrow-stop-270.png</normaloff>:/qtutils/fugue/arrow-stop-270.png</iconset>
             </property>
            </widget>
@@ -1236,8 +1236,8 @@ QToolButton:hover {
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>941</width>
-             <height>521</height>
+             <width>70</width>
+             <height>70</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -1280,7 +1280,7 @@ QToolButton:hover {
       </widget>
       <widget class="QWidget" name="tab_groups">
        <attribute name="icon">
-        <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+        <iconset resource="../../qtutils/icons/icons.qrc">
          <normaloff>:/qtutils/fugue/tables-stacks.png</normaloff>:/qtutils/fugue/tables-stacks.png</iconset>
        </attribute>
        <attribute name="title">
@@ -1334,7 +1334,7 @@ QToolButton:hover {
              <string>Open globals file</string>
             </property>
             <property name="icon">
-             <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+             <iconset resource="../../qtutils/icons/icons.qrc">
               <normaloff>:/qtutils/fugue/folder-open-table.png</normaloff>:/qtutils/fugue/folder-open-table.png</iconset>
             </property>
            </widget>
@@ -1351,7 +1351,7 @@ QToolButton:hover {
              <string>New globals file</string>
             </property>
             <property name="icon">
-             <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+             <iconset resource="../../qtutils/icons/icons.qrc">
               <normaloff>:/qtutils/fugue/table--plus.png</normaloff>:/qtutils/fugue/table--plus.png</iconset>
             </property>
            </widget>
@@ -1368,7 +1368,7 @@ QToolButton:hover {
              <string>Diff globals file</string>
             </property>
             <property name="icon">
-             <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+             <iconset resource="../../qtutils/icons/icons.qrc">
               <normaloff>:/qtutils/fugue/tables.png</normaloff>:/qtutils/fugue/tables.png</iconset>
             </property>
            </widget>
@@ -1401,8 +1401,8 @@ QToolButton:hover {
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>970</width>
-             <height>490</height>
+             <width>86</width>
+             <height>70</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -1461,7 +1461,7 @@ QToolButton:hover {
   </widget>
   <action name="actionLoad_configuration">
    <property name="icon">
-    <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+    <iconset resource="../../qtutils/icons/icons.qrc">
      <normaloff>:/qtutils/fugue/folder-open.png</normaloff>:/qtutils/fugue/folder-open.png</iconset>
    </property>
    <property name="text">
@@ -1476,7 +1476,7 @@ QToolButton:hover {
     <bool>false</bool>
    </property>
    <property name="icon">
-    <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+    <iconset resource="../../qtutils/icons/icons.qrc">
      <normaloff>:/qtutils/fugue/disk--plus.png</normaloff>:/qtutils/fugue/disk--plus.png</iconset>
    </property>
    <property name="text">
@@ -1488,7 +1488,7 @@ QToolButton:hover {
   </action>
   <action name="actionQuit">
    <property name="icon">
-    <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+    <iconset resource="../../qtutils/icons/icons.qrc">
      <normaloff>:/qtutils/fugue/cross-button.png</normaloff>:/qtutils/fugue/cross-button.png</iconset>
    </property>
    <property name="text">
@@ -1500,7 +1500,7 @@ QToolButton:hover {
   </action>
   <action name="actionSave_configuration">
    <property name="icon">
-    <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+    <iconset resource="../../qtutils/icons/icons.qrc">
      <normaloff>:/qtutils/fugue/disk.png</normaloff>:/qtutils/fugue/disk.png</iconset>
    </property>
    <property name="text">
@@ -1515,7 +1515,7 @@ QToolButton:hover {
     <bool>false</bool>
    </property>
    <property name="icon">
-    <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+    <iconset resource="../../qtutils/icons/icons.qrc">
      <normaloff>:/qtutils/fugue/arrow-curve-180-left.png</normaloff>:/qtutils/fugue/arrow-curve-180-left.png</iconset>
    </property>
    <property name="text">
@@ -1562,7 +1562,7 @@ QToolButton:hover {
   <tabstop>scrollArea_2</tabstop>
  </tabstops>
  <resources>
-  <include location="../../clones/qtutils.git/qtutils/icons/icons.qrc"/>
+  <include location="../../qtutils/icons/icons.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/runmanager/main.ui
+++ b/runmanager/main.ui
@@ -692,7 +692,7 @@ QToolButton:hover {
             <item>
              <widget class="QFrame" name="frame_2">
               <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Delay shot compilation until BLACS has the given number of shots remaining. In this case, the values of the globals listed as &amp;quot;dynamic globals&amp;quot; will be determined from their values in runmanager at the time the shot is compiled (instead of being locked in when 'engage' was clicked). This allows feedback from analysis routines or FunctionRunner devices (or any other code) that may call the runmanager.remote.set_globals() function to influence the values of globals in shots yet to be compiled. This requires the BLACS delay_compilation plugin to be enabled, to send events to runmanager advising it of how many shots BLACS has remaining.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Delay shot compilation until BLACS has the given number of shots remaining. In this case, the values of the globals listed as &amp;quot;dynamic globals&amp;quot; will be determined from their values in runmanager at the time the shot is compiled (instead of being locked in when 'engage' was clicked). This allows feedback from analysis routines or FunctionRunner devices (or any other code) that may call the runmanager.remote.set_globals() function to influence the values of globals in shots yet to be compiled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="frameShape">
                <enum>QFrame::StyledPanel</enum>
@@ -709,7 +709,7 @@ QToolButton:hover {
                  <item>
                   <widget class="QPushButton" name="button_delay_compilation">
                    <property name="text">
-                    <string>delay compilation</string>
+                    <string>Delay compilation</string>
                    </property>
                    <property name="icon">
                     <iconset resource="../../qtutils/icons/icons.qrc">
@@ -761,7 +761,7 @@ QToolButton:hover {
                     <item>
                      <widget class="QLabel" name="label_5">
                       <property name="text">
-                       <string>     until BLACS has</string>
+                       <string>     Until BLACS has</string>
                       </property>
                      </widget>
                     </item>

--- a/runmanager/main.ui
+++ b/runmanager/main.ui
@@ -14,7 +14,7 @@
    <string>runmanager - the labscript suite</string>
   </property>
   <property name="windowIcon">
-   <iconset>
+   <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
     <normaloff>:/qtutils/custom/runmanager.png</normaloff>:/qtutils/custom/runmanager.png</iconset>
   </property>
   <property name="styleSheet">
@@ -94,7 +94,16 @@ QToolButton:hover:checked {
     <property name="spacing">
      <number>0</number>
     </property>
-    <property name="margin">
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
      <number>0</number>
     </property>
     <item>
@@ -120,6 +129,47 @@ QToolButton:hover:checked {
          <property name="bottomMargin">
           <number>0</number>
          </property>
+         <item row="1" column="1">
+          <widget class="QCheckBox" name="pushButton_shuffle">
+           <property name="focusPolicy">
+            <enum>Qt::NoFocus</enum>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Send compiled shots to BLACS in a random order, to prevent scanned parameters correlating with temporal drifts.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Shuffle</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+             <normaloff>:/qtutils/fugue/arrow-switch.png</normaloff>:/qtutils/fugue/arrow-switch.png</iconset>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="tristate">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QPushButton" name="pushButton_restart_subprocess">
+           <property name="focusPolicy">
+            <enum>Qt::NoFocus</enum>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Forcefully restart the compilation subprocess, stopping any compilation in process.&lt;/p&gt;&lt;p&gt;This can be useful if the child process is misbehaving for any reason.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Restart
+subprocess</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+             <normaloff>:/qtutils/fugue/arrow-circle-135-left.png</normaloff>:/qtutils/fugue/arrow-circle-135-left.png</iconset>
+           </property>
+          </widget>
+         </item>
          <item row="0" column="1">
           <widget class="QPushButton" name="pushButton_abort">
            <property name="enabled">
@@ -136,7 +186,7 @@ QToolButton:hover:checked {
             <string>Abort</string>
            </property>
            <property name="icon">
-            <iconset>
+            <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
              <normaloff>:/qtutils/fugue/cross-octagon.png</normaloff>:/qtutils/fugue/cross-octagon.png</iconset>
            </property>
           </widget>
@@ -157,8 +207,8 @@ QToolButton:hover:checked {
            </property>
            <property name="styleSheet">
             <string notr="true">QPushButton {
-	 background-color: rgba(238,96,96,192);
-     border: 1px solid rgba(238,96,96,128);
+	 background-color: rgb(238,96,96,192);
+     border: 1px solid rgb(238,96,96,128);
 	  border-radius: 3px;
      padding: 4px;
  }
@@ -181,54 +231,13 @@ QPushButton:hover {
             <string>Engage</string>
            </property>
            <property name="icon">
-            <iconset>
+            <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
              <normaloff>:/qtutils/fugue/control.png</normaloff>:/qtutils/fugue/control.png</iconset>
            </property>
            <property name="autoDefault">
             <bool>false</bool>
            </property>
            <property name="flat">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QPushButton" name="pushButton_restart_subprocess">
-           <property name="focusPolicy">
-            <enum>Qt::NoFocus</enum>
-           </property>
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Forcefully restart the compilation subprocess, stopping any compilation in process.&lt;/p&gt;&lt;p&gt;This can be useful if the child process is misbehaving for any reason.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="text">
-            <string>Restart
-subprocess</string>
-           </property>
-           <property name="icon">
-            <iconset>
-             <normaloff>:/qtutils/fugue/arrow-circle-135-left.png</normaloff>:/qtutils/fugue/arrow-circle-135-left.png</iconset>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QCheckBox" name="pushButton_shuffle">
-           <property name="focusPolicy">
-            <enum>Qt::NoFocus</enum>
-           </property>
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Send compiled shots to BLACS in a random order, to prevent scanned parameters correlating with temporal drifts.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="text">
-            <string>Shuffle</string>
-           </property>
-           <property name="icon">
-            <iconset>
-             <normaloff>:/qtutils/fugue/arrow-switch.png</normaloff>:/qtutils/fugue/arrow-switch.png</iconset>
-           </property>
-           <property name="checkable">
-            <bool>true</bool>
-           </property>
-           <property name="tristate">
             <bool>false</bool>
            </property>
           </widget>
@@ -307,57 +316,6 @@ subprocess</string>
          <property name="bottomMargin">
           <number>6</number>
          </property>
-         <item row="2" column="1">
-          <widget class="QLineEdit" name="lineEdit_BLACS_hostname">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The host computer running BLACS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="text">
-            <string>localhost</string>
-           </property>
-           <property name="frame">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="label_3">
-           <property name="text">
-            <string>labscript file</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="2">
-          <widget class="QToolButton" name="toolButton_reset_shot_output_folder">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reset to default output folder.&lt;/p&gt;&lt;p&gt;If the folder does not exist it will be created at compile-time.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="text">
-            <string>...</string>
-           </property>
-           <property name="icon">
-            <iconset>
-             <normaloff>:/qtutils/fugue/arrow-turn-180-left.png</normaloff>:/qtutils/fugue/arrow-turn-180-left.png</iconset>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="label_2">
-           <property name="text">
-            <string>Shot output folder</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="label">
-           <property name="text">
-            <string>BLACS hostname</string>
-           </property>
-          </widget>
-         </item>
          <item row="0" column="2">
           <widget class="QToolButton" name="toolButton_edit_labscript_file">
            <property name="enabled">
@@ -370,112 +328,22 @@ subprocess</string>
             <string>...</string>
            </property>
            <property name="icon">
-            <iconset>
-             <normaloff>:/qtutils/custom/python-document.png</normaloff>:/qtutils/custom/python-document.png</iconset>
+            <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+             <normaloff>:/qtutils/fugue/document--pencil.png</normaloff>:/qtutils/fugue/document--pencil.png</iconset>
            </property>
           </widget>
          </item>
-         <item row="1" column="1">
-          <widget class="QFrame" name="frame">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
+         <item row="2" column="1">
+          <widget class="QLineEdit" name="lineEdit_BLACS_hostname">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The host computer running BLACS.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
-           <property name="sizeIncrement">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
+           <property name="text">
+            <string>localhost</string>
            </property>
-           <property name="frameShape">
-            <enum>QFrame::StyledPanel</enum>
+           <property name="frame">
+            <bool>true</bool>
            </property>
-           <layout class="QHBoxLayout" name="horizontalLayout">
-            <property name="spacing">
-             <number>0</number>
-            </property>
-            <property name="margin">
-             <number>0</number>
-            </property>
-            <item>
-             <widget class="QLineEdit" name="lineEdit_shot_output_folder">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Ignored">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The folder in which newly compiled shot files will be placed.&lt;/p&gt;&lt;p&gt;If the folder does not exist, it will be created at compile time.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-              <property name="styleSheet">
-               <string notr="true"/>
-              </property>
-              <property name="frame">
-               <bool>false</bool>
-              </property>
-              <property name="readOnly">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="label_non_default_folder">
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Non-default output folder chosen: all shots will be produced in this folder.&lt;/p&gt;&lt;p&gt;New folders will not automatically be created for new sequences/dates/etc.&lt;/p&gt;&lt;p&gt;To reset to the default output folder, click the 'reset to default output folder' button.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-              <property name="text">
-               <string/>
-              </property>
-              <property name="pixmap">
-               <pixmap>:/qtutils/fugue/exclamation-white.png</pixmap>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="Line" name="line_2">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QToolButton" name="toolButton_select_shot_output_folder">
-              <property name="enabled">
-               <bool>false</bool>
-              </property>
-              <property name="toolTip">
-               <string>Select folder ...</string>
-              </property>
-              <property name="styleSheet">
-               <string notr="true">QToolButton{
-    border: none;
-    background: white;
-    padding: 2px;
-}
-
-QToolButton:hover {
-     background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
-                                       stop: 0 #f6f7fa, stop: 1 #dadbde);
- }
-
- QToolButton:pressed {
-     background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
-                                       stop: 0 #dadbde, stop: 1 #f6f7fa);
- }</string>
-              </property>
-              <property name="text">
-               <string>...</string>
-              </property>
-              <property name="icon">
-               <iconset>
-                <normaloff>:/qtutils/fugue/folder-horizontal-open.png</normaloff>:/qtutils/fugue/folder-horizontal-open.png</iconset>
-              </property>
-             </widget>
-            </item>
-           </layout>
           </widget>
          </item>
          <item row="0" column="1">
@@ -496,7 +364,16 @@ QToolButton:hover {
             <property name="spacing">
              <number>0</number>
             </property>
-            <property name="margin">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
              <number>0</number>
             </property>
             <item>
@@ -554,12 +431,162 @@ QToolButton:hover {
                <string>...</string>
               </property>
               <property name="icon">
-               <iconset>
-                <normaloff>:/qtutils/fugue/folder-open-document-text.png</normaloff>:/qtutils/fugue/folder-open-document-text.png</iconset>
+               <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+                <normaloff>:/qtutils/custom/python-document.png</normaloff>:/qtutils/custom/python-document.png</iconset>
               </property>
              </widget>
             </item>
            </layout>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QToolButton" name="toolButton_reset_shot_output_folder">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reset to default output folder.&lt;/p&gt;&lt;p&gt;If the folder does not exist it will be created at compile-time.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>...</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+             <normaloff>:/qtutils/fugue/arrow-turn-180-left.png</normaloff>:/qtutils/fugue/arrow-turn-180-left.png</iconset>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QFrame" name="frame">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="sizeIncrement">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="frameShape">
+            <enum>QFrame::StyledPanel</enum>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QLineEdit" name="lineEdit_shot_output_folder">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Ignored">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The folder in which newly compiled shot files will be placed.&lt;/p&gt;&lt;p&gt;If the folder does not exist, it will be created at compile time.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="styleSheet">
+               <string notr="true"/>
+              </property>
+              <property name="frame">
+               <bool>false</bool>
+              </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="label_non_default_folder">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Non-default output folder chosen: all shots will be produced in this folder.&lt;/p&gt;&lt;p&gt;New folders will not automatically be created for new sequences/dates/etc.&lt;/p&gt;&lt;p&gt;To reset to the default output folder, click the 'reset to default output folder' button.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="pixmap">
+               <pixmap resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">:/qtutils/fugue/exclamation-white.png</pixmap>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="Line" name="line_2">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QToolButton" name="toolButton_select_shot_output_folder">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="toolTip">
+               <string>Select folder ...</string>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">QToolButton{
+    border: none;
+    background: white;
+    padding: 2px;
+}
+
+QToolButton:hover {
+     background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
+                                       stop: 0 #f6f7fa, stop: 1 #dadbde);
+ }
+
+ QToolButton:pressed {
+     background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
+                                       stop: 0 #dadbde, stop: 1 #f6f7fa);
+ }</string>
+              </property>
+              <property name="text">
+               <string>...</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+                <normaloff>:/qtutils/fugue/folder-horizontal-open.png</normaloff>:/qtutils/fugue/folder-horizontal-open.png</iconset>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>BLACS hostname</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Shot output folder</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_3">
+           <property name="text">
+            <string>labscript file</string>
+           </property>
           </widget>
          </item>
         </layout>
@@ -588,7 +615,7 @@ QToolButton:hover {
        <enum>QTabWidget::Rounded</enum>
       </property>
       <property name="currentIndex">
-       <number>0</number>
+       <number>1</number>
       </property>
       <property name="elideMode">
        <enum>Qt::ElideRight</enum>
@@ -607,7 +634,7 @@ QToolButton:hover {
       </property>
       <widget class="QWidget" name="tab_output">
        <attribute name="icon">
-        <iconset>
+        <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
          <normaloff>:/qtutils/fugue/terminal.png</normaloff>:/qtutils/fugue/terminal.png</iconset>
        </attribute>
        <attribute name="title">
@@ -620,7 +647,16 @@ QToolButton:hover {
         <property name="spacing">
          <number>0</number>
         </property>
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
@@ -628,9 +664,425 @@ QToolButton:hover {
         </item>
        </layout>
       </widget>
+      <widget class="QWidget" name="tab_queue">
+       <attribute name="icon">
+        <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+         <normaloff>:/qtutils/fugue/edit-list-order.png</normaloff>:/qtutils/fugue/edit-list-order.png</iconset>
+       </attribute>
+       <attribute name="title">
+        <string>Queue</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_11">
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_10">
+          <property name="leftMargin">
+           <number>6</number>
+          </property>
+          <property name="topMargin">
+           <number>6</number>
+          </property>
+          <property name="rightMargin">
+           <number>6</number>
+          </property>
+          <property name="bottomMargin">
+           <number>6</number>
+          </property>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_7">
+            <item>
+             <spacer name="horizontalSpacer_5">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QFrame" name="frame_2">
+              <property name="frameShape">
+               <enum>QFrame::StyledPanel</enum>
+              </property>
+              <property name="frameShadow">
+               <enum>QFrame::Raised</enum>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_12">
+               <item>
+                <widget class="QRadioButton" name="radioButton">
+                 <property name="text">
+                  <string>Ahead-of-time compilation</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QRadioButton" name="radioButton_2">
+                 <property name="text">
+                  <string>Just-in-time compilation</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayout_6">
+                 <item>
+                  <widget class="QLabel" name="label_4">
+                   <property name="text">
+                    <string>        Dynamic globals: (comma-separated list)</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLineEdit" name="lineEdit_dynamic_globals">
+                   <property name="minimumSize">
+                    <size>
+                     <width>300</width>
+                     <height>0</height>
+                    </size>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayout_9">
+                 <item>
+                  <widget class="QLabel" name="label_5">
+                   <property name="text">
+                    <string>        Compile next when BLACS has</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QSpinBox" name="spinBox"/>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="label_6">
+                   <property name="text">
+                    <string>shot(s) left</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_2">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_6">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_10">
+            <item>
+             <spacer name="horizontalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QFrame" name="queue_controls_frame">
+              <property name="frameShape">
+               <enum>QFrame::StyledPanel</enum>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_3">
+               <property name="leftMargin">
+                <number>6</number>
+               </property>
+               <property name="topMargin">
+                <number>6</number>
+               </property>
+               <property name="rightMargin">
+                <number>6</number>
+               </property>
+               <property name="bottomMargin">
+                <number>6</number>
+               </property>
+               <item>
+                <layout class="QHBoxLayout" name="queue_control_buttons_horizontalLayout">
+                 <property name="spacing">
+                  <number>6</number>
+                 </property>
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <widget class="QPushButton" name="queue_pause_button">
+                   <property name="focusPolicy">
+                    <enum>Qt::NoFocus</enum>
+                   </property>
+                   <property name="toolTip">
+                    <string>Pause the queue</string>
+                   </property>
+                   <property name="text">
+                    <string>Pause</string>
+                   </property>
+                   <property name="icon">
+                    <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+                     <normaloff>:/qtutils/fugue/control-pause.png</normaloff>:/qtutils/fugue/control-pause.png</iconset>
+                   </property>
+                   <property name="checkable">
+                    <bool>true</bool>
+                   </property>
+                   <property name="checked">
+                    <bool>false</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <layout class="QHBoxLayout" name="horizontalLayout_8">
+                   <property name="spacing">
+                    <number>0</number>
+                   </property>
+                   <property name="leftMargin">
+                    <number>0</number>
+                   </property>
+                   <item>
+                    <widget class="QPushButton" name="queue_repeat_button">
+                     <property name="focusPolicy">
+                      <enum>Qt::NoFocus</enum>
+                     </property>
+                     <property name="toolTip">
+                      <string>Re-add shots to the end of the queue after completion</string>
+                     </property>
+                     <property name="text">
+                      <string>Repeat</string>
+                     </property>
+                     <property name="icon">
+                      <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+                       <normaloff>:/qtutils/fugue/arrow-repeat.png</normaloff>:/qtutils/fugue/arrow-repeat.png</iconset>
+                     </property>
+                     <property name="checkable">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QToolButton" name="repeat_mode_select_button">
+                     <property name="toolTip">
+                      <string>Select repeat mode</string>
+                     </property>
+                     <property name="text">
+                      <string/>
+                     </property>
+                     <property name="icon">
+                      <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+                       <normaloff>:/qtutils/fugue/control-270.png</normaloff>:/qtutils/fugue/control-270.png</iconset>
+                     </property>
+                     <property name="iconSize">
+                      <size>
+                       <width>8</width>
+                       <height>19</height>
+                      </size>
+                     </property>
+                     <property name="popupMode">
+                      <enum>QToolButton::InstantPopup</enum>
+                     </property>
+                     <property name="arrowType">
+                      <enum>Qt::NoArrow</enum>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </item>
+                </layout>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_11">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <item>
+             <layout class="QVBoxLayout" name="verticalLayout_9">
+              <property name="spacing">
+               <number>6</number>
+              </property>
+              <property name="leftMargin">
+               <number>3</number>
+              </property>
+              <property name="rightMargin">
+               <number>3</number>
+              </property>
+              <item>
+               <widget class="QToolButton" name="toolButton_remove_shots">
+                <property name="toolTip">
+                 <string>Remove selected sequences/shots</string>
+                </property>
+                <property name="text">
+                 <string>...</string>
+                </property>
+                <property name="icon">
+                 <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+                  <normaloff>:/qtutils/fugue/minus.png</normaloff>:/qtutils/fugue/minus.png</iconset>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="verticalSpacer_3">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>40</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QToolButton" name="toolButton_axis_to_top_2">
+                <property name="toolTip">
+                 <string>Move selected to top</string>
+                </property>
+                <property name="text">
+                 <string>...</string>
+                </property>
+                <property name="icon">
+                 <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+                  <normaloff>:/qtutils/fugue/arrow-stop-090.png</normaloff>:/qtutils/fugue/arrow-stop-090.png</iconset>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QToolButton" name="toolButton_axis_up_2">
+                <property name="toolTip">
+                 <string>Move selected up</string>
+                </property>
+                <property name="text">
+                 <string>...</string>
+                </property>
+                <property name="icon">
+                 <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+                  <normaloff>:/qtutils/fugue/arrow-090.png</normaloff>:/qtutils/fugue/arrow-090.png</iconset>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QToolButton" name="toolButton_axis_down_2">
+                <property name="toolTip">
+                 <string>Move selected down</string>
+                </property>
+                <property name="text">
+                 <string>...</string>
+                </property>
+                <property name="icon">
+                 <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+                  <normaloff>:/qtutils/fugue/arrow-270.png</normaloff>:/qtutils/fugue/arrow-270.png</iconset>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QToolButton" name="toolButton_axis_to_bottom_2">
+                <property name="toolTip">
+                 <string>Move selected to bottom</string>
+                </property>
+                <property name="text">
+                 <string>...</string>
+                </property>
+                <property name="icon">
+                 <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+                  <normaloff>:/qtutils/fugue/arrow-stop-270.png</normaloff>:/qtutils/fugue/arrow-stop-270.png</iconset>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="verticalSpacer_4">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>40</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="TreeView" name="treeView_queue">
+              <property name="alternatingRowColors">
+               <bool>true</bool>
+              </property>
+              <property name="selectionMode">
+               <enum>QAbstractItemView::ExtendedSelection</enum>
+              </property>
+              <property name="textElideMode">
+               <enum>Qt::ElideLeft</enum>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
       <widget class="QWidget" name="tab_axes">
        <attribute name="icon">
-        <iconset>
+        <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
          <normaloff>:/qtutils/custom/outer.png</normaloff>:/qtutils/custom/outer.png</iconset>
        </attribute>
        <attribute name="title">
@@ -643,7 +1095,16 @@ QToolButton:hover {
         <property name="spacing">
          <number>0</number>
         </property>
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
@@ -679,7 +1140,7 @@ QToolButton:hover {
              <string>...</string>
             </property>
             <property name="icon">
-             <iconset>
+             <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
               <normaloff>:/qtutils/fugue/arrow-stop-090.png</normaloff>:/qtutils/fugue/arrow-stop-090.png</iconset>
             </property>
            </widget>
@@ -693,7 +1154,7 @@ QToolButton:hover {
              <string>...</string>
             </property>
             <property name="icon">
-             <iconset>
+             <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
               <normaloff>:/qtutils/fugue/arrow-090.png</normaloff>:/qtutils/fugue/arrow-090.png</iconset>
             </property>
            </widget>
@@ -707,7 +1168,7 @@ QToolButton:hover {
              <string>...</string>
             </property>
             <property name="icon">
-             <iconset>
+             <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
               <normaloff>:/qtutils/fugue/arrow-270.png</normaloff>:/qtutils/fugue/arrow-270.png</iconset>
             </property>
            </widget>
@@ -721,7 +1182,7 @@ QToolButton:hover {
              <string>...</string>
             </property>
             <property name="icon">
-             <iconset>
+             <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
               <normaloff>:/qtutils/fugue/arrow-stop-270.png</normaloff>:/qtutils/fugue/arrow-stop-270.png</iconset>
             </property>
            </widget>
@@ -754,15 +1215,24 @@ QToolButton:hover {
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>926</width>
-             <height>486</height>
+             <width>941</width>
+             <height>521</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_7">
             <property name="spacing">
              <number>0</number>
             </property>
-            <property name="margin">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
              <number>0</number>
             </property>
             <item>
@@ -770,14 +1240,14 @@ QToolButton:hover {
               <property name="editTriggers">
                <set>QAbstractItemView::NoEditTriggers</set>
               </property>
+              <property name="alternatingRowColors">
+               <bool>true</bool>
+              </property>
               <property name="selectionMode">
                <enum>QAbstractItemView::ExtendedSelection</enum>
               </property>
               <property name="selectionBehavior">
                <enum>QAbstractItemView::SelectRows</enum>
-              </property>
-              <property name="alternatingRowColors">
-               <bool>true</bool>
               </property>
              </widget>
             </item>
@@ -789,7 +1259,7 @@ QToolButton:hover {
       </widget>
       <widget class="QWidget" name="tab_groups">
        <attribute name="icon">
-        <iconset>
+        <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
          <normaloff>:/qtutils/fugue/tables-stacks.png</normaloff>:/qtutils/fugue/tables-stacks.png</iconset>
        </attribute>
        <attribute name="title">
@@ -802,7 +1272,16 @@ QToolButton:hover {
         <property name="spacing">
          <number>0</number>
         </property>
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
@@ -810,7 +1289,16 @@ QToolButton:hover {
           <property name="spacing">
            <number>9</number>
           </property>
-          <property name="margin">
+          <property name="leftMargin">
+           <number>3</number>
+          </property>
+          <property name="topMargin">
+           <number>3</number>
+          </property>
+          <property name="rightMargin">
+           <number>3</number>
+          </property>
+          <property name="bottomMargin">
            <number>3</number>
           </property>
           <item>
@@ -825,7 +1313,7 @@ QToolButton:hover {
              <string>Open globals file</string>
             </property>
             <property name="icon">
-             <iconset>
+             <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
               <normaloff>:/qtutils/fugue/folder-open-table.png</normaloff>:/qtutils/fugue/folder-open-table.png</iconset>
             </property>
            </widget>
@@ -842,7 +1330,7 @@ QToolButton:hover {
              <string>New globals file</string>
             </property>
             <property name="icon">
-             <iconset>
+             <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
               <normaloff>:/qtutils/fugue/table--plus.png</normaloff>:/qtutils/fugue/table--plus.png</iconset>
             </property>
            </widget>
@@ -859,7 +1347,7 @@ QToolButton:hover {
              <string>Diff globals file</string>
             </property>
             <property name="icon">
-             <iconset>
+             <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
               <normaloff>:/qtutils/fugue/tables.png</normaloff>:/qtutils/fugue/tables.png</iconset>
             </property>
            </widget>
@@ -892,15 +1380,24 @@ QToolButton:hover {
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>963</width>
-             <height>448</height>
+             <width>970</width>
+             <height>490</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_6">
             <property name="spacing">
              <number>0</number>
             </property>
-            <property name="margin">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
              <number>0</number>
             </property>
             <item>
@@ -926,7 +1423,7 @@ QToolButton:hover {
      <x>0</x>
      <y>0</y>
      <width>1000</width>
-     <height>31</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -943,7 +1440,7 @@ QToolButton:hover {
   </widget>
   <action name="actionLoad_configuration">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
      <normaloff>:/qtutils/fugue/folder-open.png</normaloff>:/qtutils/fugue/folder-open.png</iconset>
    </property>
    <property name="text">
@@ -958,7 +1455,7 @@ QToolButton:hover {
     <bool>false</bool>
    </property>
    <property name="icon">
-    <iconset>
+    <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
      <normaloff>:/qtutils/fugue/disk--plus.png</normaloff>:/qtutils/fugue/disk--plus.png</iconset>
    </property>
    <property name="text">
@@ -970,7 +1467,7 @@ QToolButton:hover {
   </action>
   <action name="actionQuit">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
      <normaloff>:/qtutils/fugue/cross-button.png</normaloff>:/qtutils/fugue/cross-button.png</iconset>
    </property>
    <property name="text">
@@ -982,7 +1479,7 @@ QToolButton:hover {
   </action>
   <action name="actionSave_configuration">
    <property name="icon">
-    <iconset>
+    <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
      <normaloff>:/qtutils/fugue/disk.png</normaloff>:/qtutils/fugue/disk.png</iconset>
    </property>
    <property name="text">
@@ -997,7 +1494,7 @@ QToolButton:hover {
     <bool>false</bool>
    </property>
    <property name="icon">
-    <iconset>
+    <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
      <normaloff>:/qtutils/fugue/arrow-curve-180-left.png</normaloff>:/qtutils/fugue/arrow-curve-180-left.png</iconset>
    </property>
    <property name="text">
@@ -1044,7 +1541,7 @@ QToolButton:hover {
   <tabstop>scrollArea_2</tabstop>
  </tabstops>
  <resources>
-  <include location="../../Anaconda/Lib/site-packages/qtutils/icons/icons.qrc"/>
+  <include location="../../clones/qtutils.git/qtutils/icons/icons.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/runmanager/main.ui
+++ b/runmanager/main.ui
@@ -690,20 +690,10 @@ QToolButton:hover {
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout_7">
             <item>
-             <spacer name="horizontalSpacer_5">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
              <widget class="QFrame" name="frame_2">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Delay shot compilation until BLACS has the given number of shots remaining. In this case, the values of the globals listed as &amp;quot;dynamic globals&amp;quot; will be determined from their values in runmanager at the time the shot is compiled (instead of being locked in when 'engage' was clicked). This allows feedback from analysis routines or FunctionRunner devices (or any other code) that may call the runmanager.remote.set_globals() function to influence the values of globals in shots yet to be compiled. This requires the BLACS delay_compilation plugin to be enabled, to send events to runmanager advising it of how many shots BLACS has remaining.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
               <property name="frameShape">
                <enum>QFrame::StyledPanel</enum>
               </property>
@@ -712,64 +702,26 @@ QToolButton:hover {
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_12">
                <item>
-                <widget class="QRadioButton" name="radioButton">
-                 <property name="text">
-                  <string>Ahead-of-time compilation</string>
+                <layout class="QHBoxLayout" name="horizontalLayout_12">
+                 <property name="topMargin">
+                  <number>0</number>
                  </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QRadioButton" name="radioButton_2">
-                 <property name="text">
-                  <string>Just-in-time compilation</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <layout class="QHBoxLayout" name="horizontalLayout_6">
                  <item>
-                  <widget class="QLabel" name="label_4">
+                  <widget class="QPushButton" name="button_delay_compilation">
                    <property name="text">
-                    <string>        Dynamic globals: (comma-separated list)</string>
+                    <string>delay compilation</string>
+                   </property>
+                   <property name="icon">
+                    <iconset resource="../../clones/qtutils.git/qtutils/icons/icons.qrc">
+                     <normaloff>:/qtutils/fugue/alarm-clock--arrow.png</normaloff>:/qtutils/fugue/alarm-clock--arrow.png</iconset>
+                   </property>
+                   <property name="checkable">
+                    <bool>true</bool>
                    </property>
                   </widget>
                  </item>
                  <item>
-                  <widget class="QLineEdit" name="lineEdit_dynamic_globals">
-                   <property name="minimumSize">
-                    <size>
-                     <width>300</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item>
-                <layout class="QHBoxLayout" name="horizontalLayout_9">
-                 <item>
-                  <widget class="QLabel" name="label_5">
-                   <property name="text">
-                    <string>        Compile next when BLACS has</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="spinBox"/>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="label_6">
-                   <property name="text">
-                    <string>shot(s) left</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_2">
+                  <spacer name="horizontalSpacer_7">
                    <property name="orientation">
                     <enum>Qt::Horizontal</enum>
                    </property>
@@ -783,21 +735,90 @@ QToolButton:hover {
                  </item>
                 </layout>
                </item>
+               <item>
+                <widget class="QWidget" name="delay_compilation_options" native="true">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_13">
+                  <property name="leftMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>0</number>
+                  </property>
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_9">
+                    <property name="topMargin">
+                     <number>0</number>
+                    </property>
+                    <item>
+                     <widget class="QLabel" name="label_5">
+                      <property name="text">
+                       <string>     until BLACS has</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QSpinBox" name="spinBox_delayed_num_shots"/>
+                    </item>
+                    <item>
+                     <widget class="QLabel" name="label_6">
+                      <property name="text">
+                       <string>shot(s) left</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <spacer name="horizontalSpacer_2">
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>40</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                     </spacer>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_6">
+                    <item>
+                     <widget class="QLabel" name="label_4">
+                      <property name="enabled">
+                       <bool>true</bool>
+                      </property>
+                      <property name="text">
+                       <string>     Dynamic globals: (comma-separated list)</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QLineEdit" name="lineEdit_dynamic_globals">
+                      <property name="minimumSize">
+                       <size>
+                        <width>300</width>
+                        <height>0</height>
+                       </size>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
               </layout>
              </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_6">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
             </item>
            </layout>
           </item>

--- a/runmanager/main.ui
+++ b/runmanager/main.ui
@@ -207,8 +207,8 @@ subprocess</string>
            </property>
            <property name="styleSheet">
             <string notr="true">QPushButton {
-	 background-color: rgb(238,96,96,192);
-     border: 1px solid rgb(238,96,96,128);
+	 background-color: rgba(238,96,96,192);
+     border: 1px solid rgba(238,96,96,128);
 	  border-radius: 3px;
      padding: 4px;
  }
@@ -329,7 +329,7 @@ QPushButton:hover {
            </property>
            <property name="icon">
             <iconset resource="../../qtutils/icons/icons.qrc">
-             <normaloff>:/qtutils/fugue/document--pencil.png</normaloff>:/qtutils/fugue/document--pencil.png</iconset>
+             <normaloff>:/qtutils/custom/python-document.png</normaloff>:/qtutils/custom/python-document.png</iconset>
            </property>
           </widget>
          </item>
@@ -432,7 +432,7 @@ QToolButton:hover {
               </property>
               <property name="icon">
                <iconset resource="../../qtutils/icons/icons.qrc">
-                <normaloff>:/qtutils/custom/python-document.png</normaloff>:/qtutils/custom/python-document.png</iconset>
+                <normaloff>:/qtutils/fugue/folder-open-document-text.png</normaloff>:/qtutils/fugue/folder-open-document-text.png</iconset>
               </property>
              </widget>
             </item>

--- a/runmanager/remote.py
+++ b/runmanager/remote.py
@@ -113,6 +113,13 @@ class Client(ZMQClient):
         """Reset the shot output folder to the default path"""
         return self.request('reset_shot_output_folder')
 
+    def advise_BLACS_shots_remaining(self, value):
+        """Tell runmanager how many shots BLACS has left before its queue is empty -
+        that is, the number of shots in its queue, plus one if a shot has been removed
+        from the queue but has not finished running. This is so that if runmanager's
+        compilation queue is configured for just-in-time compilation, it can compile and
+        submit the next shot when BLACS has a certain number of shots left."""
+        return self.request('advise_BLACS_queue_size', value)
 
 _default_client = Client()
 

--- a/runmanager/remote.py
+++ b/runmanager/remote.py
@@ -22,8 +22,9 @@ class Client(ZMQClient):
         self.timeout = timeout
 
     def request(self, command, *args, **kwargs):
+        timeout = kwargs.pop('timeout', self.timeout)
         return self.get(
-            self.port, self.host, data=[command, args, kwargs], timeout=self.timeout
+            self.port, self.host, data=[command, args, kwargs], timeout=timeout
         )
 
     def say_hello(self):
@@ -119,7 +120,7 @@ class Client(ZMQClient):
         from the queue but has not finished running. This is so that if runmanager's
         compilation queue is configured for just-in-time compilation, it can compile and
         submit the next shot when BLACS has a certain number of shots left."""
-        return self.request('advise_BLACS_queue_size', value)
+        return self.request('advise_BLACS_shots_remaining', value)
 
 _default_client = Client()
 
@@ -145,6 +146,7 @@ set_shot_output_folder = _default_client.set_shot_output_folder
 error_in_globals = _default_client.error_in_globals
 is_output_folder_default = _default_client.is_output_folder_default
 reset_shot_output_folder = _default_client.reset_shot_output_folder
+advise_BLACS_shots_remaining = _default_client.advise_BLACS_shots_remaining
 
 if __name__ == '__main__':
     # Test


### PR DESCRIPTION
This introduces a compilation queue for runmanager. When compiling, sequences and shots yet to be compiled appear in this queue. It can be paused, set to repeat, items deleted and reordered.

![image](https://user-images.githubusercontent.com/1044087/148510900-2e86600f-269e-40f2-a06d-a8133da8e508.png)

This:

a) Allows you to monitor the progress of compilation, including queuing up multiple sequences to be compiled, removing some sequences or shots, etc.

b) Includes a "delayed compilation" mode. Shot compilation will be delayed until BLACS' queue has emptied to the specified number of shots. This is desirable since some globals can be marked as "dynamic" globals, whose values *at compile time* will be used, rather than the values those globals had when the compilation was queued up.

![image](https://user-images.githubusercontent.com/1044087/148511875-19f31e98-66c2-4fa8-b032-dff5ac8c00ae.png)

An intended use case is to allow for intra-sequence feedback that modifies globals for future shots within the same sequence, based on results of shots earlier in the sequence.

This can be implemented by defining a FunctionRunner device in your experiment script, which has a function that runs at the end of the shot to read some data from the HDF5 file, do whatever analysis is needed and call the runmanager remote API to set the value of a global.

The reason this should be done with a FunctionRunner instead of from a lyse routine is because lyse analysis is asynchronous - shots will be analysed in lyse after some delay, and analysis routines may run multiple times. So this is not appropriate for feedback that needs to be synchronous.

This PR requires the corresponding change to BLACS for it to report back to runmanager how many shots it has remaining in its queue. This method, of having BLACS report to runmanager after each shot, and at regular intervals, how many shots it has remaining, seems like one of the only ways to organise this communication that won't result in deadlocks where both runmanager and BLACS are waiting for each other. But I'm open to other suggestions for this!

Yet to be implemented:

[] deletion of shots from queue
[] reordering of shots in queue
[] repetition of shots in queue

Not super happy with:

[] interface for specifying dynamic globals as a comma-separated list. Some list widget would be better, maybe. But don't want to overcomplicate things.