### PR TITLE
Prevent import of h5_lock during docs build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,6 +16,10 @@ from pathlib import Path
 from m2r import MdInclude
 from recommonmark.transform import AutoStructify
 from jinja2 import FileSystemLoader, Environment
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    import importlib_metadata
 
 # -- Project information (unique to each project) -------------------------------------
 
@@ -24,7 +28,7 @@ copyright = "2020, labscript suite"
 author = "labscript suite contributors"
 
 # The full version, including alpha/beta/rc tags
-from runmanager import __version__ as version  # noqa: E402
+version = importlib_metadata.version('runmanager')
 
 release = version
 


### PR DESCRIPTION
Update `conf.py` to get version using importlib_metadata to avoid incidental import of labscript_utils.h5_lock.

Build already mocks labscript_utils.