### PR TITLE
Get shot globals deprecation

### DIFF
--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -23,5 +23,4 @@ python:
         path: .
         extra_requirements:
             - docs
-   system_packages: true
    

--- a/runmanager/__init__.py
+++ b/runmanager/__init__.py
@@ -33,7 +33,7 @@ import numpy as np
 
 from labscript_utils.ls_zprocess import ProcessTree, zmq_push_multipart
 from labscript_utils.labconfig import LabConfig
-import labscript_utils
+import labscript_utils.shot_utils
 process_tree = ProcessTree.instance()
 
 from .__version__ import __version__

--- a/runmanager/__init__.py
+++ b/runmanager/__init__.py
@@ -25,6 +25,7 @@ import errno
 import json
 import tokenize
 import io
+import warnings
 
 import labscript_utils.h5_lock
 import h5py
@@ -32,6 +33,7 @@ import numpy as np
 
 from labscript_utils.ls_zprocess import ProcessTree, zmq_push_multipart
 from labscript_utils.labconfig import LabConfig
+import labscript_utils
 process_tree = ProcessTree.instance()
 
 from .__version__ import __version__
@@ -915,24 +917,16 @@ def compile_labscript_with_globals_files_async(labscript_file, globals_files, ou
 def get_shot_globals(filepath):
     """Returns the evaluated globals for a shot, for use by labscript or lyse.
     Simple dictionary access as in dict(h5py.File(filepath).attrs) would be fine
-    except we want to apply some hacks, so it's best to do that in one place."""
-    params = {}
-    with h5py.File(filepath, 'r') as f:
-        for name, value in f['globals'].attrs.items():
-            # Convert numpy bools to normal bools:
-            if isinstance(value, np.bool_):
-                value = bool(value)
-            # Convert null HDF references to None:
-            if isinstance(value, h5py.Reference) and not value:
-                value = None
-            # Convert numpy strings to Python ones.
-            # DEPRECATED, for backward compat with old files.
-            if isinstance(value, np.str_):
-                value = str(value)
-            if isinstance(value, bytes):
-                value = value.decode()
-            params[name] = value
-    return params
+    except we want to apply some hacks, so it's best to do that in one place.
+    
+    Deprecated: use identical function `labscript_utils.shot_utils.get_shot_globals`
+    """
+    
+    warnings.warn(
+        DeprecationWarning("This function has moved to labscript_utils.shot_utils. "
+                           "Please update your code to import it from there."))
+
+    return labscript_utils.shot_utils.get_shot_globals(filepath)
 
 
 def dict_diff(dict1, dict2):

--- a/runmanager/__init__.py
+++ b/runmanager/__init__.py
@@ -923,8 +923,8 @@ def get_shot_globals(filepath):
     """
     
     warnings.warn(
-        DeprecationWarning("This function has moved to labscript_utils.shot_utils. "
-                           "Please update your code to import it from there."))
+        FutureWarning("get_shot_globals has moved to labscript_utils.shot_utils. "
+                      "Please update your code to import it from there."))
 
     return labscript_utils.shot_utils.get_shot_globals(filepath)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
   desktop-app>=0.1.2
   importlib_metadata
   labscript>=3.0.0
-  labscript_utils>=3.0.0
+  labscript_utils>=3.3.0
   pandas>=0.13
   qtutils>=2.2.2
   matplotlib


### PR DESCRIPTION
PR adds a deprecation warning to `get_shot_globals` function to notify users to update their imports to use `labscript_utils.shot_utils.get_shot_globals` instead.