### PR TITLE
Compiler cleanup

### DIFF
--- a/runmanager/__init__.py
+++ b/runmanager/__init__.py
@@ -137,7 +137,7 @@ def add_expansion_groups(filename):
         requires_expansion_group = []
         for groupname in f['globals']:
             group = f['globals'][groupname]
-            if not 'expansion' in group:
+            if 'expansion' not in group:
                 requires_expansion_group.append(groupname)
     if requires_expansion_group:
         group_globalslists = [get_globalslist(filename, groupname) for groupname in requires_expansion_group]
@@ -512,7 +512,7 @@ def evaluate_globals(sequence_globals, raise_exceptions=True):
         for global_name in sequence_globals[group_name]:
             # Do not attempt to override exception objects already stored
             # as the result of multiply defined globals:
-            if not global_name in results[group_name]:
+            if global_name not in results[group_name]:
                 results[group_name][global_name] = evaled_globals[global_name]
 
     return results, global_hierarchy, expansions

--- a/runmanager/__init__.py
+++ b/runmanager/__init__.py
@@ -809,24 +809,6 @@ def make_run_file_from_globals_files(labscript_file, globals_files, output_path,
     )
     make_single_run_file(output_path, sequence_globals, shots[0], sequence_attrs, 1, 1)
 
-
-def compile_labscript(labscript_file, run_file):
-    """Compiles labscript_file with the run file, returning
-    the processes return code, stdout and stderr."""
-    proc = subprocess.Popen([sys.executable, labscript_file, run_file], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    stdout, stderr = proc.communicate()
-    return proc.returncode, stdout, stderr
-
-
-def compile_labscript_with_globals_files(labscript_file, globals_files, output_path):
-    """Creates a run file output_path, using all the globals from
-    globals_files. Compiles labscript_file with the run file, returning
-    the processes return code, stdout and stderr."""
-    make_run_file_from_globals_files(labscript_file, globals_files, output_path)
-    returncode, stdout, stderr = compile_labscript(labscript_file, output_path)
-    return returncode, stdout, stderr
-
-
 def compile_labscript_async(labscript_file, run_file, stream_port, done_callback):
     """Compiles labscript_file with run_file. This function is designed to be called in
     a thread.  The stdout and stderr from the compilation will be shovelled into


### PR DESCRIPTION
Fixes #114 

This PR removes the deprecated synchronous compilation functions. It also adds default arguments to `labscript_compile_async` and `compile_multishot_async` so that they can run in a script using default arguments. Finally, I brushed up a few docstrings to clarify usage a bit.