### PR TITLE
Show active config path in window title

### DIFF
--- a/runmanager/__main__.py
+++ b/runmanager/__main__.py
@@ -54,7 +54,12 @@ PYQT_VERSION_STR = importlib.metadata.version(QT_ENV)
 
 splash.update_text('importing labscript suite modules')
 from labscript_utils.ls_zprocess import zmq_get, ProcessTree, ZMQServer
-from labscript_utils.labconfig import LabConfig, save_appconfig, load_appconfig
+from labscript_utils.labconfig import (
+    LabConfig,
+    LabscriptApplication,
+    save_appconfig,
+    load_appconfig,
+)
 from labscript_utils.setup_logging import setup_logging
 import labscript_utils.shared_drive as shared_drive
 from labscript_utils import dedent
@@ -1475,7 +1480,10 @@ class PoppedOutOutputBoxWindow(QtWidgets.QDialog):
         app.on_output_popout_button_clicked()
 
 
-class RunManager(object):
+class RunManager(LabscriptApplication):
+
+    app_name = 'runmanager'
+    default_config_filename = 'runmanager.ini'
 
     # Constants for the model in the axes tab:
     AXES_COL_NAME = 0
@@ -1533,6 +1541,7 @@ class RunManager(object):
         self.output_box_window.setWindowTitle('runmanager output')
         self.output_box_window.resize(800, 1000)
         self.setup_config()
+        self.init_config_window_title()
         self.setup_axes_tab()
         self.setup_groups_tab()
         self.connect_signals()
@@ -1605,11 +1614,13 @@ class RunManager(object):
         self.last_save_data = None
 
         # autoload a config file, if labconfig is set to do so:
+        active_config_file = self.get_default_config_file()
         try:
             autoload_config_file = self.exp_config.get('runmanager', 'autoload_config_file')
         except (LabConfig.NoOptionError, LabConfig.NoSectionError):
             self.output_box.output('Ready.\n\n')
         else:
+            active_config_file = autoload_config_file
             self.ui.setEnabled(False)
             self.output_box.output('Loading default config file %s...' % autoload_config_file)
 
@@ -1628,6 +1639,7 @@ class RunManager(object):
             # so that the GUI pops up faster in the meantime
             self.ui.firstPaint.connect(lambda: QtCore.QTimer.singleShot(50, load_the_config_file))
 
+        self.set_config_window_title(active_config_file)
         splash.update_text('done')
         self.ui.show()
 
@@ -1792,12 +1804,12 @@ class RunManager(object):
             self.groups_model.itemChanged, self.on_groups_model_item_changed)
         
         # Keyboard shortcuts:
-        engage_shortcut = QtGui.QShortcut('F5', self.ui,
+        engage_shortcut = QtWidgets.QShortcut('F5', self.ui,
             lambda: self.ui.pushButton_engage.clicked.emit(False))
         engage_shortcut.setAutoRepeat(False)
-        QtGui.QShortcut('ctrl+W', self.ui, self.close_current_tab)
-        QtGui.QShortcut('ctrl+Tab', self.ui, lambda: self.switch_tabs(+1))
-        QtGui.QShortcut('ctrl+shift+Tab', self.ui, lambda: self.switch_tabs(-1))
+        QtWidgets.QShortcut('ctrl+W', self.ui, self.close_current_tab)
+        QtWidgets.QShortcut('ctrl+Tab', self.ui, lambda: self.switch_tabs(+1))
+        QtWidgets.QShortcut('ctrl+shift+Tab', self.ui, lambda: self.switch_tabs(-1))
         self.logger.info('Signals connected')
 
     def on_close_event(self):
@@ -3140,7 +3152,7 @@ class RunManager(object):
         if self.last_save_config_file is not None:
             default = self.last_save_config_file
         else:
-            default = os.path.join(self.exp_config.get('paths', 'experiment_shot_storage'), 'runmanager.ini')
+            default = self.get_default_config_file(ensure_directory=True)
         save_file = QtWidgets.QFileDialog.getSaveFileName(self.ui,
                                                       'Select  file to save current runmanager configuration',
                                                       default,
@@ -3224,6 +3236,7 @@ class RunManager(object):
         self.last_save_config_file = save_file
         self.last_save_data = save_data
         save_appconfig(save_file, {'runmanager_state': save_data})
+        self.set_config_window_title(save_file)
 
     def on_load_configuration_triggered(self):
         save_data = self.get_save_data()
@@ -3240,7 +3253,7 @@ class RunManager(object):
         if self.last_save_config_file is not None:
             default = self.last_save_config_file
         else:
-            default = os.path.join(self.exp_config.get('paths', 'experiment_shot_storage'), 'runmanager.ini')
+            default = self.get_default_config_file()
 
         file = QtWidgets.QFileDialog.getOpenFileName(self.ui,
                                                  'Select runmanager configuration file to load',
@@ -3356,6 +3369,7 @@ class RunManager(object):
         self.last_save_data = save_data
         self.ui.actionSave_configuration_as.setEnabled(True)
         self.ui.actionRevert_configuration.setEnabled(True)
+        self.set_config_window_title(filename)
 
     def compile_loop(self):
         while True:


### PR DESCRIPTION
change the title bar of the main window of all labscript apps to read "app name - path to app_config_file" for example "runmanager - ~/labscript-suite/app_saved_configs/example_apparatus/runmanager/runmanager.ini". 

This is helpful in verifying that the app is actually accessing the desired configuration file, which has been an ofttimes issue locally.